### PR TITLE
Falsche Angabe von Ram free / used bei Debian Stretch

### DIFF
--- a/FHEM/42_SYSMON.pm
+++ b/FHEM/42_SYSMON.pm
@@ -2263,7 +2263,11 @@ sub SYSMON_getRamAndSwap($$) {
   if($hash->{helper}->{excludes}{'ramswap'}) {return $map;}
 
   #my @speicher = qx(free -m);
-  my @speicher = SYSMON_execute($hash, "LANG=en free");
+  #my @speicher = SYSMON_execute($hash, "LANG=en free");
+  my $free_version = SYSMON_execute($hash, 'free -V');
+  $free_version =~ s/\D//g;
+  my @speicher = SYSMON_execute($hash, 'LANG=en ' . ($free_version > 339 ? 'free -w' : 'free'));
+
 
   if(!@speicher) {
     return $map;
@@ -2312,7 +2316,8 @@ sub SYSMON_getRamAndSwap($$) {
     }
     #$used_clean = $used - $buffers - $cached;
     #$ram = sprintf("Total: %.2f MB, Used: %.2f MB, %.2f %%, Free: %.2f MB", $total, $used_clean, ($used_clean / $total * 100), ($free + $buffers + $cached));
-    if ($total > 2048) {
+    #if ($total > 2048) {
+    if ($free_version > 339) {
        $used_clean = $used;
        $ram = sprintf("Total: %.2f MB, Used: %.2f MB, %.2f %%, Free: %.2f MB", $total, $used_clean, ($used_clean / $total * 100), ($free));
      } else {


### PR DESCRIPTION
Debian Stretch bringt eine neue Version  (3.3.12) des Komandos free. Bei Jessie war das 3.3.9. Leider hat das Ausgabeformat gewechselt. Nach eingem Rumprobieren habe ich die Funktion SYSMON_getRamAndSwap angepasst, so dass sie bei meinen diversen RaspberryPi's ( 1,2 und 3) mit unterschiedlichen Systemen (Jessie, Stretch) korrekte Werte liefert.
- Die Auswertung der Version lässt sich ev. etwas eleganter lösen, ein Problem sehe ich wenn die Versionsnummer nur noch aus zwei Zahlen besteht :-(
- Die Abfrage ($total > 2048) scheint mir etwas seltsam zu sein, für meine Zwecke konnte ich sie jedoch gut gebrauchen. Ich habe kein Gerät das diese Bedingung erfüllt. Ev. sind die beiden Abfragen mit einem || zu kombinieren.

Wäre toll wenn diese Anpassungen in die offizielle Version einfliessen könnte
Gruss
Stefan